### PR TITLE
These aren't part of the XDG standard

### DIFF
--- a/chck/xdg/test.c
+++ b/chck/xdg/test.c
@@ -15,14 +15,6 @@ main(void)
       printf("%s\n", (ret = xdg_get_path("XDG_CONFIG_HOME", ".config"))); free(ret);
       printf("%s\n", (ret = xdg_get_path("XDG_DATA_HOME", ".local/share"))); free(ret);
       printf("%s\n", (ret = xdg_get_path("XDG_CACHE_HOME", ".cache"))); free(ret);
-      printf("%s\n", (ret = xdg_get_path("XDG_DESKTOP_DIR", "Desktop"))); free(ret);
-      printf("%s\n", (ret = xdg_get_path("XDG_DOWNLOAD_DIR", "Downloads"))); free(ret);
-      printf("%s\n", (ret = xdg_get_path("XDG_TEMPLATES_DIR", "Templates"))); free(ret);
-      printf("%s\n", (ret = xdg_get_path("XDG_PUBLICSHARE_DIR", "Public"))); free(ret);
-      printf("%s\n", (ret = xdg_get_path("XDG_DOCUMENTS_DIR", "Documents"))); free(ret);
-      printf("%s\n", (ret = xdg_get_path("XDG_MUSIC_DIR", "Music"))); free(ret);
-      printf("%s\n", (ret = xdg_get_path("XDG_PICTURES_DIR", "Pictures"))); free(ret);
-      printf("%s\n", (ret = xdg_get_path("XDG_VIDEOS_DIR", "Videos"))); free(ret);
       printf("%s\n", (ret = xdg_get_path("XDG_THIS_DOES_NOT_EXIST", "but_mah_path_is_still_here"))); free(ret);
 
       const char *path;


### PR DESCRIPTION
Although they look part of it, they're not, and actually use a different
mechanism (see `user-dirs.dirs`) which requires its own
shell-like-but-not-quite parsing as they're not environment variables.

So for example the current tests will assume `/home/earnest/Desktop` is
correct for `XDG_DESKTOP_HOME` when it's actually defined to be
```
    XDG_DESKTOP_DIR="$HOME/"
```
in my `XDG_CONFIG_HOME/user-dirs.dirs file`.  (The quotes and trailing `/`
is actually required.)